### PR TITLE
Fix: Group chat > sometimes blue thick mark not working

### DIFF
--- a/lib/src/controllers/chat_page/mixins/get_message.dart
+++ b/lib/src/controllers/chat_page/mixins/get_message.dart
@@ -303,6 +303,7 @@ mixin IsmChatPageGetMessageMixin on GetxController {
       return;
     }
     _controller.deliverdMessageMembers = response;
+    _syncMessageStatusFlags(message);
   }
 
   Future<void> getMessageReadTime(IsmChatMessageModel message) async {
@@ -316,6 +317,55 @@ mixin IsmChatPageGetMessageMixin on GetxController {
       return;
     }
     _controller.readMessageMembers = response;
+    _syncMessageStatusFlags(message);
+  }
+
+  void _syncMessageStatusFlags(IsmChatMessageModel message) {
+    final isGroup = _controller.conversation?.isGroup ?? false;
+    final membersCount = _controller.conversation?.membersCount ?? 0;
+    final expectedRecipients =
+        isGroup ? (membersCount > 0 ? membersCount - 1 : 0) : 1;
+    final deliveredCount = _controller.deliverdMessageMembers.length;
+    final readCount = _controller.readMessageMembers.length;
+
+    var deliveredToAll = message.deliveredToAll ?? false;
+    var readByAll = message.readByAll ?? false;
+
+    if (isGroup) {
+      if (expectedRecipients > 0 && deliveredCount > 0) {
+        deliveredToAll = deliveredCount >= expectedRecipients;
+      }
+      if (expectedRecipients > 0 && readCount > 0) {
+        readByAll = readCount >= expectedRecipients;
+        if (readByAll) {
+          deliveredToAll = true;
+        }
+      }
+    } else {
+      if (deliveredCount > 0) {
+        deliveredToAll = true;
+      }
+      if (readCount > 0) {
+        readByAll = true;
+        deliveredToAll = true;
+      }
+    }
+
+    if (deliveredToAll == (message.deliveredToAll ?? false) &&
+        readByAll == (message.readByAll ?? false)) {
+      return;
+    }
+
+    final index = _controller.messages
+        .indexWhere((m) => m.messageId == message.messageId);
+    if (index == -1) {
+      return;
+    }
+
+    _controller.messages[index] = _controller.messages[index].copyWith(
+      deliveredToAll: deliveredToAll,
+      readByAll: readByAll,
+    );
   }
 
   Future<IsmChatConversationModel?> getConverstaionDetails(

--- a/lib/src/views/chat_page/widget/message_info.dart
+++ b/lib/src/views/chat_page/widget/message_info.dart
@@ -83,17 +83,58 @@ class IsmChatMessageInfo extends StatelessWidget {
                     ),
                   ),
                   IsmChatDimens.boxHeight16,
-                  Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: message.sentByMe
-                        ? CrossAxisAlignment.end
-                        : CrossAxisAlignment.start,
-                    children: [
-                      MessageBubble(
-                        message: message,
-                        showMessageInCenter: false,
-                      )
-                    ],
+                  Obx(
+                    () {
+                      final deliveredCount =
+                          chatController.deliverdMessageMembers.length;
+                      final readCount =
+                          chatController.readMessageMembers.length;
+                      final membersCount =
+                          chatController.conversation?.membersCount ?? 0;
+                      final expectedRecipients = isGroup
+                          ? (membersCount > 0 ? membersCount - 1 : 0)
+                          : 1;
+
+                      var deliveredToAll = message.deliveredToAll ?? false;
+                      var readByAll = message.readByAll ?? false;
+
+                      if (isGroup) {
+                        if (expectedRecipients > 0 && deliveredCount > 0) {
+                          deliveredToAll =
+                              deliveredCount >= expectedRecipients;
+                        }
+                        if (expectedRecipients > 0 && readCount > 0) {
+                          readByAll = readCount >= expectedRecipients;
+                          if (readByAll) {
+                            deliveredToAll = true;
+                          }
+                        }
+                      } else {
+                        if (deliveredCount > 0) {
+                          deliveredToAll = true;
+                        }
+                        if (readCount > 0) {
+                          readByAll = true;
+                          deliveredToAll = true;
+                        }
+                      }
+
+                      return Column(
+                        mainAxisSize: MainAxisSize.min,
+                        crossAxisAlignment: message.sentByMe
+                            ? CrossAxisAlignment.end
+                            : CrossAxisAlignment.start,
+                        children: [
+                          MessageBubble(
+                            message: message.copyWith(
+                              deliveredToAll: deliveredToAll,
+                              readByAll: readByAll,
+                            ),
+                            showMessageInCenter: false,
+                          )
+                        ],
+                      );
+                    },
                   ),
                   IsmChatDimens.boxHeight16,
                   isGroup


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses the synchronization of message delivery and read status indicators in group chat conversations. It introduces logic to accurately determine whether all recipients have received (delivered) and read each message, updating the message state accordingly. The changes ensure that the "delivered to all" and "read by all" flags are correctly set based on the number of message members who have acknowledged the message, providing more reliable visual indicators for message status in both group and individual chats.
<!-- kody-pr-summary:end -->