### PR TITLE
Feature: Mute conversation push notification

### DIFF
--- a/example/lib/controllers/chat_list/chat_list_controller.dart
+++ b/example/lib/controllers/chat_list/chat_list_controller.dart
@@ -39,7 +39,6 @@ class ChatListController extends GetxController {
     super.onClose();
   }
 
-
   /// Stops the last active timer
   void _stopLastActiveTimer() {
     _lastActiveTimer?.cancel();

--- a/lib/src/controllers/chat_conversations/mixins/conversation_operations.dart
+++ b/lib/src/controllers/chat_conversations/mixins/conversation_operations.dart
@@ -446,16 +446,78 @@ mixin IsmChatConversationsConversationOperationsMixin on GetxController {
   /// `conversationId`: The ID of the conversation to update.
   /// `events`: The events to update in the conversation.
   /// `isLoading`: Indicates if loading should be shown.
-  Future<void> updateConversationSetting({
+  ///
+  /// On success, syncs `pushNotifications` (and nested `config`) locally so the
+  /// mute toggle and MQTT local notification gating stay consistent.
+  Future<bool> updateConversationSetting({
     required String conversationId,
     required IsmChatEvents events,
     bool isLoading = false,
   }) async {
-    await _controller.viewModel.updateConversationSetting(
+    final response = await _controller.viewModel.updateConversationSetting(
       conversationId: conversationId,
       events: events,
       isLoading: isLoading,
     );
+    if (response == null || response.hasError) {
+      return false;
+    }
+    if (events.pushNotifications != null) {
+      await _syncLocalPushNotifications(
+        conversationId: conversationId,
+        pushNotifications: events.pushNotifications!,
+      );
+    }
+    return true;
+  }
+
+  /// Persists mute / push-notification setting across DB, list, and open chat.
+  Future<void> _syncLocalPushNotifications({
+    required String conversationId,
+    required bool pushNotifications,
+  }) async {
+    var conversation =
+        await IsmChatConfig.dbWrapper?.getConversation(conversationId);
+    conversation ??= getConversation(conversationId);
+    if (conversation == null &&
+        IsmChatUtility.chatPageControllerRegistered &&
+        IsmChatUtility.chatPageController.conversation?.conversationId ==
+            conversationId) {
+      conversation = IsmChatUtility.chatPageController.conversation;
+    }
+    if (conversation == null) return;
+
+    final updated = conversation.copyWith(
+      pushNotifications: pushNotifications,
+      config: (conversation.config ??
+              ConversationConfigModel(
+                typingEvents: true,
+                readEvents: true,
+                pushNotifications: pushNotifications,
+              ))
+          .copyWith(pushNotifications: pushNotifications),
+    );
+
+    await IsmChatConfig.dbWrapper?.saveConversation(conversation: updated);
+
+    final index = _controller.conversations
+        .indexWhere((e) => e.conversationId == conversationId);
+    if (index != -1) {
+      final list = List<IsmChatConversationModel>.from(_controller.conversations);
+      list[index] = updated;
+      _controller.conversations = list;
+    }
+
+    if (_controller.currentConversationId == conversationId) {
+      _controller.currentConversation = updated;
+    }
+
+    if (IsmChatUtility.chatPageControllerRegistered) {
+      final chatController = IsmChatUtility.chatPageController;
+      if (chatController.conversation?.conversationId == conversationId) {
+        chatController.conversation = updated;
+      }
+    }
   }
 
   int _groupAdminCount(IsmChatConversationModel conversation) {

--- a/lib/src/controllers/mqtt/mixins/mqtt_event/message_handlers.dart
+++ b/lib/src/controllers/mqtt/mixins/mqtt_event/message_handlers.dart
@@ -124,7 +124,7 @@ mixin IsmChatMqttEventMessageHandlersMixin {
   /// Handles a local notification.
   ///
   /// * `message`: The message to handle
-  void handleLocalNotification(IsmChatMessageModel message) {
+  Future<void> handleLocalNotification(IsmChatMessageModel message) async {
     final self = this;
     if (self is IsmChatMqttEventUtilitiesMixin) {
       final utils = self as IsmChatMqttEventUtilitiesMixin;
@@ -137,6 +137,22 @@ mixin IsmChatMqttEventMessageHandlersMixin {
         message.events?.sendPushNotification == false) {
       return;
     }
+
+    // Skip local alerts when this conversation has push notifications muted.
+    final conversationId = message.conversationId ?? '';
+    if (conversationId.isNotEmpty) {
+      IsmChatConversationModel? conversation;
+      if (IsmChatUtility.conversationControllerRegistered) {
+        conversation = IsmChatUtility.conversationController
+            .getConversation(conversationId);
+      }
+      conversation ??=
+          await IsmChatConfig.dbWrapper?.getConversation(conversationId);
+      if (conversation?.config?.pushNotifications == false) {
+        return;
+      }
+    }
+
     final notificationTitle = resolveMessageNotificationTitle(message);
     final notificationBody = _resolveNotificationBody(
       message,

--- a/lib/src/res/strings.dart
+++ b/lib/src/res/strings.dart
@@ -148,6 +148,7 @@ class IsmChatStrings {
   static const String addDescription = 'Add group description';
   static const String groupInfo = 'Group Info';
   static const String profileInfo = 'Profile Info';
+  static const String muteNotifications = 'Mute notifications';
   static const String edit = 'Edit';
 
   static const String areYouSure = 'Are you sure?';

--- a/lib/src/views/chat_page/widget/conversation_info.dart
+++ b/lib/src/views/chat_page/widget/conversation_info.dart
@@ -38,6 +38,7 @@ class _IsmChatConverstaionInfoViewState
   final ScrollController _scrollController = ScrollController();
   final FocusNode _participantsSearchFocusNode = FocusNode();
   final GlobalKey _participantsSearchKey = GlobalKey();
+  bool _isUpdatingMute = false;
 
   @override
   void initState() {
@@ -76,6 +77,26 @@ class _IsmChatConverstaionInfoViewState
         '${member.metaData?.firstName ?? ''} ${member.metaData?.lastName ?? ''}'
             .trim();
     return fullName.isNotEmpty ? fullName : member.userName;
+  }
+
+  /// Mute ON ⇒ `pushNotifications: false` on the conversation settings API.
+  Future<void> _onMuteNotificationsChanged(
+    IsmChatPageController controller,
+    bool isMuted,
+  ) async {
+    final conversationId = controller.conversation?.conversationId;
+    if (conversationId == null || conversationId.isEmpty) return;
+    setState(() => _isUpdatingMute = true);
+    try {
+      await conversationController.updateConversationSetting(
+        conversationId: conversationId,
+        events: IsmChatEvents(pushNotifications: !isMuted),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isUpdatingMute = false);
+      }
+    }
   }
 
   @override
@@ -437,6 +458,45 @@ class _IsmChatConverstaionInfoViewState
                                   ),
                                 ],
                               ),
+                            ),
+                          ),
+                          IsmChatDimens.boxHeight10,
+                          Container(
+                            padding: IsmChatDimens.edgeInsets16_8_16_8,
+                            decoration: BoxDecoration(
+                              borderRadius:
+                                  BorderRadius.circular(IsmChatDimens.sixteen),
+                              color: groupTheme.surfaceBackgroundColor,
+                            ),
+                            child: Row(
+                              children: [
+                                Icon(
+                                  Icons.notifications_off_outlined,
+                                  color: groupTheme.actionIconColor,
+                                  size: IsmChatDimens.twentyFour,
+                                ),
+                                IsmChatDimens.boxWidth12,
+                                Expanded(
+                                  child: Text(
+                                    IsmChatStrings.muteNotifications,
+                                    style: groupTheme.sectionTitleTextStyle,
+                                  ),
+                                ),
+                                Switch.adaptive(
+                                  value: !(controller.conversation?.config
+                                          ?.pushNotifications ??
+                                      true),
+                                  activeTrackColor:
+                                      IsmChatConfig.chatTheme.primaryColor,
+                                  onChanged: _isUpdatingMute
+                                      ? null
+                                      : (isMuted) =>
+                                          _onMuteNotificationsChanged(
+                                            controller,
+                                            isMuted,
+                                          ),
+                                ),
+                              ],
                             ),
                           ),
                         ],


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a "Mute notifications" feature for conversations. It allows users to mute or unmute push notifications within a chat, with the mute state being synchronized across the local database, in-memory models, and UI components. When a user toggles the mute switch, the app updates the conversation's push notification setting via the API, and the change is reflected immediately in the conversation list, open chat, and conversation info screen. Additionally, the local notification handler respects the mute setting by suppressing notifications for muted conversations. Overall, this enhancement provides users with better control over notification preferences at the conversation level.
<!-- kody-pr-summary:end -->