### PR TITLE
Fix: Notification Title and body content for FCM fixed

### DIFF
--- a/lib/src/controllers/chat_conversations/mixins/pending_messages.dart
+++ b/lib/src/controllers/chat_conversations/mixins/pending_messages.dart
@@ -28,12 +28,19 @@ mixin IsmChatConversationsPendingMessagesMixin on GetxController {
     if (messages.isEmpty) {
       return;
     }
-    final notificationTitle =
+    final senderUserName =
         IsmChatConfig.communicationConfig.userConfig.userName ??
             _controller.userDetails?.userName ??
             '';
 
     for (final x in messages.values) {
+      final conversation = _controller.getConversation(x.conversationId ?? '') ??
+          await IsmChatConfig.dbWrapper?.getConversation(x.conversationId ?? '');
+      final notificationTitle = IsmChatUtility.resolveSendNotificationTitle(
+        conversation: conversation,
+        conversationId: x.conversationId,
+        senderUserName: senderUserName,
+      );
       List<Map<String, dynamic>>? attachments;
       if ([
         IsmChatCustomMessageType.image,

--- a/lib/src/controllers/chat_page/mixins/send_message_core.dart
+++ b/lib/src/controllers/chat_page/mixins/send_message_core.dart
@@ -57,6 +57,20 @@ mixin IsmChatPageSendMessageCoreMixin {
     bool encrypted = false,
     List<String>? searchableTags,
   }) async {
+    // Same as local MQTT notifications: prefer conversationTitle when present.
+    notificationTitle = IsmChatUtility.resolveSendNotificationTitle(
+      conversation: _controller.conversation,
+      conversationId: conversationId,
+      senderUserName: notificationTitle,
+    );
+    // Backend uses notificationBody for FCM — never send ciphertext.
+    if (encrypted) {
+      notificationBody = IsmChatUtility.resolveEncryptedNotificationBody(
+        notificationBody: notificationBody,
+        body: body,
+        conversationId: conversationId,
+      );
+    }
     notificationBody = IsmChatConfig.notificationBody?.call(notificationBody,
             IsmChatCustomMessageType.fromString(customType)) ??
         notificationBody;
@@ -307,17 +321,21 @@ mixin IsmChatPageSendMessageCoreMixin {
       }
     }
     final encrypted = IsmChatConfig.messageEncrypted ?? false;
+    final plainBody = textMessage.body;
     var body = encrypted
         ? IsmChatUtility.encryptMessage(
-            textMessage.body,
+            plainBody,
             conversationId,
           )
-        : textMessage.body;
+        : plainBody;
     final notificationTitle =
         IsmChatConfig.communicationConfig.userConfig.userName ??
             _controller.conversationController.userDetails?.userName ??
             '';
-    final notificationBody = body;
+    // FCM preview: plaintext truncated when encrypted; full text otherwise.
+    final notificationBody = encrypted
+        ? IsmChatUtility.truncateNotificationBody(plainBody)
+        : plainBody;
     _controller.sendMessage(
       isBroadcast: _controller.isBroadcast,
       metaData: textMessage.metaData,

--- a/lib/src/controllers/mqtt/mixins/mqtt_event/message_handlers.dart
+++ b/lib/src/controllers/mqtt/mixins/mqtt_event/message_handlers.dart
@@ -212,7 +212,9 @@ String _resolveNotificationBody(
   required bool preferNotificationBody,
 }) {
   if (message.encrypted == true) {
-    return _truncateNotificationBody(_decryptedNotificationBody(message));
+    return IsmChatUtility.truncateNotificationBody(
+      _decryptedNotificationBody(message),
+    );
   }
   if (preferNotificationBody) {
     return message.notificationBody ?? '';
@@ -233,9 +235,4 @@ String _decryptedNotificationBody(IsmChatMessageModel message) {
       ? groupcastId
       : message.conversationId ?? '';
   return IsmChatUtility.decryptMessage(encryptedText, decryptionId);
-}
-
-String _truncateNotificationBody(String text) {
-  if (text.length <= 10) return text;
-  return '${text.substring(0, 10)}...';
 }

--- a/lib/src/repositories/chat_conversations_repository.dart
+++ b/lib/src/repositories/chat_conversations_repository.dart
@@ -416,6 +416,13 @@ class IsmChatConversationsRepository {
       List<Map<String, dynamic>>? attachments,
       bool isLoading = false}) async {
     try {
+      final fcmNotificationBody = encrypted
+          ? IsmChatUtility.resolveEncryptedNotificationBody(
+              notificationBody: notificationBody,
+              body: body,
+              conversationId: '',
+            )
+          : notificationBody;
       final payload = {
         'userIds': userIds,
         'showInConversation': showInConversation,
@@ -427,7 +434,7 @@ class IsmChatConversationsRepository {
         'events': events,
         'customType': customType,
         'attachments': attachments,
-        'notificationBody': notificationBody,
+        'notificationBody': fcmNotificationBody,
         'notificationTitle': notificationTitle,
         'searchableTags': searchableTags,
       }.removeNullValues();

--- a/lib/src/repositories/chat_page_repository.dart
+++ b/lib/src/repositories/chat_page_repository.dart
@@ -684,13 +684,20 @@ class IsmChatPageRepository {
       List<Map<String, dynamic>>? mentionedUsers,
       bool isLoading = false}) async {
     try {
+      final fcmNotificationBody = encrypted
+          ? IsmChatUtility.resolveEncryptedNotificationBody(
+              notificationBody: notificationBody,
+              body: body,
+              conversationId: groupcastId,
+            )
+          : notificationBody;
       final payload = <String, dynamic>{
         'showInConversation': showInConversation,
         'sendPushForNewConversationCreated': sendPushForNewConversationCreated,
         'searchableTags': searchableTags,
         'parentMessageId': parentMessageId,
         'notifyOnCompletion': notifyOnCompletion,
-        'notificationBody': notificationBody,
+        'notificationBody': fcmNotificationBody,
         'notificationTitle': notificationTitle,
         'messageType': messageType,
         'metaData': metaData?.toMap(),

--- a/lib/src/repositories/common_repository.dart
+++ b/lib/src/repositories/common_repository.dart
@@ -71,6 +71,13 @@ class IsmChatCommonRepository {
     List<String>? searchableTags,
   }) async {
     try {
+      final fcmNotificationBody = encrypted
+          ? IsmChatUtility.resolveEncryptedNotificationBody(
+              notificationBody: notificationBody,
+              body: body,
+              conversationId: conversationId,
+            )
+          : notificationBody;
       final payload = {
         'showInConversation': showInConversation,
         'messageType': messageType,
@@ -83,7 +90,7 @@ class IsmChatCommonRepository {
         'events': events,
         'customType': customType,
         'attachments': attachments,
-        'notificationBody': notificationBody,
+        'notificationBody': fcmNotificationBody,
         'notificationTitle': notificationTitle,
         if (searchableTags != null)
           'searchableTags': searchableTags
@@ -130,6 +137,13 @@ class IsmChatCommonRepository {
     List<Map<String, dynamic>>? attachments,
   }) async {
     try {
+      final fcmNotificationBody = encrypted
+          ? IsmChatUtility.resolveEncryptedNotificationBody(
+              notificationBody: notificationBody,
+              body: body,
+              conversationId: conversationId,
+            )
+          : notificationBody;
       final payload = {
         'showInConversation': showInConversation,
         'messageType': messageType,
@@ -142,7 +156,7 @@ class IsmChatCommonRepository {
         'events': events,
         'customType': customType,
         'attachments': attachments,
-        'notificationBody': notificationBody,
+        'notificationBody': fcmNotificationBody,
         'notificationTitle': notificationTitle,
         if (!(IsmChatConfig.messageEncrypted == true &&
             IsmChatCustomMessageType.fromString(customType) ==

--- a/lib/src/utilities/utility.dart
+++ b/lib/src/utilities/utility.dart
@@ -179,6 +179,48 @@ class IsmChatUtility {
     }
   }
 
+  /// Truncates notification preview text for FCM / local notifications.
+  static String truncateNotificationBody(String text, {int maxLength = 10}) {
+    if (text.length <= maxLength) return text;
+    return '${text.substring(0, maxLength)}...';
+  }
+
+  /// Builds FCM-safe notification body for encrypted messages.
+  ///
+  /// If [notificationBody] was set to the encrypted [body], decrypts it first.
+  /// Always returns a truncated plaintext preview.
+  static String resolveEncryptedNotificationBody({
+    required String notificationBody,
+    required String body,
+    required String conversationId,
+  }) {
+    final plain = notificationBody == body
+        ? decryptMessage(body, conversationId)
+        : notificationBody;
+    return truncateNotificationBody(plain);
+  }
+
+  /// FCM / push notification title for outgoing messages.
+  ///
+  /// Same rule as local MQTT notifications: prefer conversationTitle when
+  /// present (group chats). Fall back to [senderUserName] for 1:1.
+  static String resolveSendNotificationTitle({
+    IsmChatConversationModel? conversation,
+    String? conversationId,
+    required String senderUserName,
+  }) {
+    final title = conversation?.conversationTitle?.trim() ?? '';
+    if (title.isNotEmpty) return title;
+
+    final id = conversationId ?? conversation?.conversationId ?? '';
+    if (id.isNotEmpty && conversationControllerRegistered) {
+      final cached =
+          conversationController.getConversation(id)?.conversationTitle?.trim();
+      if (cached != null && cached.isNotEmpty) return cached;
+    }
+    return senderUserName;
+  }
+
   /// Shared toast helper — uses the platform native toast on mobile.
   /// All call sites should use this helper rather than [Fluttertoast] directly.
   static void showToast(String message, {int timeOutInSec = 1}) {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request fixes the handling of notification titles and bodies for FCM and local notifications in chat messages. It ensures that outgoing message notifications display appropriate titles—preferring conversation titles for group chats and sender names for individual chats—and that notification bodies are decrypted and truncated properly when messages are encrypted. These improvements enhance the clarity and consistency of notification content across different message types and encryption states.
<!-- kody-pr-summary:end -->