### PR TITLE
Feature/mask sensitive content

### DIFF
--- a/example/lib/controllers/chat_list/chat_list_controller.dart
+++ b/example/lib/controllers/chat_list/chat_list_controller.dart
@@ -69,6 +69,7 @@ class ChatListController extends GetxController {
   void initialize() async {
     IsmChatLog.error(AppConfig.userDetail?.toJson());
     await IsmChat.i.initialize(
+      maskSensitiveContent: true,
       messageEncrypted: true,
       kNavigatorKey: kNavigatorKey,
       communicationConfig: IsmChatCommunicationConfig(

--- a/lib/delegate/delegate_initialization.dart
+++ b/lib/delegate/delegate_initialization.dart
@@ -25,6 +25,7 @@ mixin IsmChatDelegateInitializationMixin {
     IsmMqttProperties? mqttProperties,
     bool? isMonthFirst,
     bool messageEncrypted = false,
+    bool maskSensitiveContent = false,
     NotificationBodyCallback? notificationBody,
   }) async {
     final initTimer = IsmChatInitTimer(
@@ -33,6 +34,7 @@ mixin IsmChatDelegateInitializationMixin {
     );
     IsmChatConfig.kNavigatorKey = kNavigatorKey;
     IsmChatConfig.messageEncrypted = messageEncrypted;
+    IsmChatConfig.maskSensitiveContent = maskSensitiveContent;
     IsmChatConfig.notificationBody = notificationBody;
     IsmChatConfig.dbName = databaseName;
     IsmChatConfig.useDatabase = !kIsWeb && useDatabase;

--- a/lib/mixins/initialization.dart
+++ b/lib/mixins/initialization.dart
@@ -65,6 +65,9 @@ mixin IsmChatInitializationMixin {
   /// - `mqttProperties`: MQTT-specific properties (optional).
   /// - `isMonthFirst`: Date format preference (optional).
   /// - `messageEncrypted`: Whether messages are encrypted. Defaults to `false`.
+  /// - `maskSensitiveContent`: When `true`, mask email/phone/social URLs in
+  ///   local UI/DB on send, but still POST the original body to the API.
+  ///   Defaults to `false` (no masking).
   /// - `notificationBody`: Callback for custom notification body (optional).
   ///
   /// **Throws:**
@@ -104,6 +107,7 @@ mixin IsmChatInitializationMixin {
     IsmMqttProperties? mqttProperties,
     bool? isMonthFirst,
     bool messageEncrypted = false,
+    bool maskSensitiveContent = false,
     NotificationBodyCallback? notificationBody,
   }) async {
     if (sendPaidWalletMessage != null) {
@@ -142,6 +146,7 @@ mixin IsmChatInitializationMixin {
       mqttProperties: mqttProperties,
       isMonthFirst: isMonthFirst,
       messageEncrypted: messageEncrypted,
+      maskSensitiveContent: maskSensitiveContent,
       notificationBody: notificationBody,
     );
     // Set static field - IsmChat is defined in the same library (part of)

--- a/lib/src/controllers/chat_conversations/mixins/pending_messages.dart
+++ b/lib/src/controllers/chat_conversations/mixins/pending_messages.dart
@@ -120,15 +120,40 @@ mixin IsmChatConversationsPendingMessagesMixin on GetxController {
         events: {'updateUnreadCount': true, 'sendPushNotification': true},
         attachments: attachments,
         mentionedUsers: x.mentionedUsers?.map((e) => e.toMap()).toList(),
-        metaData: x.metaData,
+        metaData: IsmChatSensitiveContentMasker.stripLocalUnmaskedFromMeta(
+          x.metaData,
+        ),
         messageType: x.messageType?.value ?? 0,
         customType: x.customType?.name ?? '',
         parentMessageId: x.parentMessageId,
         deviceId: x.deviceId ?? '',
         conversationId: x.conversationId ?? '',
-        notificationBody: x.body,
+        notificationBody: () {
+          final apiPlain = IsmChatSensitiveContentMasker.resolveApiBody(
+            storedBody: x.body,
+            metaData: x.metaData,
+          );
+          final encrypted = x.customType == IsmChatCustomMessageType.text &&
+              (IsmChatConfig.messageEncrypted ?? false);
+          return encrypted
+              ? IsmChatUtility.truncateNotificationBody(apiPlain)
+              : apiPlain;
+        }(),
         notificationTitle: notificationTitle,
-        body: x.body,
+        body: () {
+          final apiPlain = IsmChatSensitiveContentMasker.resolveApiBody(
+            storedBody: x.body,
+            metaData: x.metaData,
+          );
+          final encrypted = x.customType == IsmChatCustomMessageType.text &&
+              (IsmChatConfig.messageEncrypted ?? false);
+          return encrypted
+              ? IsmChatUtility.encryptMessage(
+                  apiPlain,
+                  x.conversationId ?? '',
+                )
+              : apiPlain;
+        }(),
         createdAt: x.sentAt,
         isBroadcast: IsmChatUtility.chatPageControllerRegistered
             ? IsmChatUtility.chatPageController.isBroadcast

--- a/lib/src/controllers/chat_page/mixins/send_message_core.dart
+++ b/lib/src/controllers/chat_page/mixins/send_message_core.dart
@@ -195,8 +195,16 @@ mixin IsmChatPageSendMessageCoreMixin {
         conversationId: conversationId, userId: userId);
     final sentAt = DateTime.now().millisecondsSinceEpoch;
 
+    // Original text for backend / FCM; masked text for local UI + DB when enabled.
+    final originalBody = _controller.chatInputController.text.trim();
+    final maskingEnabled = IsmChatConfig.maskSensitiveContent;
+    final displayBody = IsmChatSensitiveContentMasker.applyIfEnabled(
+      originalBody,
+      enabled: maskingEnabled,
+    );
+
     var textMessage = IsmChatMessageModel(
-      body: _controller.chatInputController.text.trim(),
+      body: displayBody,
       conversationId: conversationId,
       senderInfo: _controller.currentUser,
       customType: _controller.isreplying
@@ -214,29 +222,38 @@ mixin IsmChatPageSendMessageCoreMixin {
       readByAll: false,
       sentAt: sentAt,
       sentByMe: true,
-      metaData: IsmChatMetaData(
-        messageSentAt: sentAt,
-        isOnelyEmoji: IsmChatUtility.isOnlyEmoji(
-          _controller.chatInputController.text.trim(),
-        ),
-        replyMessage: _controller.isreplying
-            ? IsmChatReplyMessageModel(
-                forMessageType: IsmChatCustomMessageType.text,
-                parentMessageAttachmentUrl:
-                    _controller.getParentMessageUrl(_controller.replayMessage),
-                parentMessageAttachmentDuration:
-                    _controller.replayMessage?.metaData?.duration?.inSeconds,
-                parentMessageMessageType: _controller.replayMessage?.customType,
-                parentMessageInitiator: _controller.replayMessage?.sentByMe,
-                parentMessageBody:
-                    _controller.getMessageBody(_controller.replayMessage),
-                parentMessageUserId:
-                    _controller.replayMessage?.senderInfo?.userId,
-                parentMessageUserName:
-                    _controller.replayMessage?.senderInfo?.userName ?? '',
-              )
-            : null,
-      ),
+      metaData: () {
+        final meta = IsmChatMetaData(
+          messageSentAt: sentAt,
+          isOnelyEmoji: IsmChatUtility.isOnlyEmoji(originalBody),
+          replyMessage: _controller.isreplying
+              ? IsmChatReplyMessageModel(
+                  forMessageType: IsmChatCustomMessageType.text,
+                  parentMessageAttachmentUrl:
+                      _controller.getParentMessageUrl(_controller.replayMessage),
+                  parentMessageAttachmentDuration:
+                      _controller.replayMessage?.metaData?.duration?.inSeconds,
+                  parentMessageMessageType:
+                      _controller.replayMessage?.customType,
+                  parentMessageInitiator: _controller.replayMessage?.sentByMe,
+                  parentMessageBody:
+                      _controller.getMessageBody(_controller.replayMessage),
+                  parentMessageUserId:
+                      _controller.replayMessage?.senderInfo?.userId,
+                  parentMessageUserName:
+                      _controller.replayMessage?.senderInfo?.userName ?? '',
+                )
+              : null,
+        );
+        // Keep original only on device for pending retry; stripped before API.
+        if (maskingEnabled && originalBody != displayBody) {
+          return IsmChatSensitiveContentMasker.attachLocalUnmasked(
+            meta: meta,
+            originalBody: originalBody,
+          );
+        }
+        return meta;
+      }(),
       mentionedUsers: _controller.userMentionedList.map(
         (e) {
           var user =
@@ -321,24 +338,30 @@ mixin IsmChatPageSendMessageCoreMixin {
       }
     }
     final encrypted = IsmChatConfig.messageEncrypted ?? false;
-    final plainBody = textMessage.body;
+    // Backend always gets the original (unmasked) plaintext / ciphertext.
+    final apiPlainBody = IsmChatSensitiveContentMasker.resolveApiBody(
+      storedBody: textMessage.body,
+      metaData: textMessage.metaData,
+    );
     var body = encrypted
         ? IsmChatUtility.encryptMessage(
-            plainBody,
+            apiPlainBody,
             conversationId,
           )
-        : plainBody;
+        : apiPlainBody;
     final notificationTitle =
         IsmChatConfig.communicationConfig.userConfig.userName ??
             _controller.conversationController.userDetails?.userName ??
             '';
-    // FCM preview: plaintext truncated when encrypted; full text otherwise.
+    // FCM preview: plaintext truncated when encrypted; full original otherwise.
     final notificationBody = encrypted
-        ? IsmChatUtility.truncateNotificationBody(plainBody)
-        : plainBody;
+        ? IsmChatUtility.truncateNotificationBody(apiPlainBody)
+        : apiPlainBody;
     _controller.sendMessage(
       isBroadcast: _controller.isBroadcast,
-      metaData: textMessage.metaData,
+      metaData: IsmChatSensitiveContentMasker.stripLocalUnmaskedFromMeta(
+        textMessage.metaData,
+      ),
       deviceId: textMessage.deviceId ?? '',
       body: body,
       customType: textMessage.customType?.value ?? '',

--- a/lib/src/repositories/chat_conversations_repository.dart
+++ b/lib/src/repositories/chat_conversations_repository.dart
@@ -430,7 +430,9 @@ class IsmChatConversationsRepository {
         'encrypted': encrypted,
         'deviceId': deviceId,
         'body': body,
-        'metaData': metaData?.toMap(),
+        'metaData': IsmChatSensitiveContentMasker.stripLocalUnmaskedFromMeta(
+          metaData,
+        )?.toMap(),
         'events': events,
         'customType': customType,
         'attachments': attachments,

--- a/lib/src/repositories/chat_page_repository.dart
+++ b/lib/src/repositories/chat_page_repository.dart
@@ -706,7 +706,9 @@ class IsmChatPageRepository {
         'notificationBody': fcmNotificationBody,
         'notificationTitle': notificationTitle,
         'messageType': messageType,
-        'metaData': metaData?.toMap(),
+        'metaData': IsmChatSensitiveContentMasker.stripLocalUnmaskedFromMeta(
+          metaData,
+        )?.toMap(),
         'hideNewConversationsForSender': hideNewConversationsForSender,
         'groupcastId': groupcastId,
         'events': events,

--- a/lib/src/repositories/common_repository.dart
+++ b/lib/src/repositories/common_repository.dart
@@ -86,7 +86,9 @@ class IsmChatCommonRepository {
         'conversationId': conversationId,
         'body': body,
         'parentMessageId': parentMessageId,
-        'metaData': metaData?.toMap(),
+        'metaData': IsmChatSensitiveContentMasker.stripLocalUnmaskedFromMeta(
+          metaData,
+        )?.toMap(),
         'events': events,
         'customType': customType,
         'attachments': attachments,

--- a/lib/src/utilities/config/chat_config.dart
+++ b/lib/src/utilities/config/chat_config.dart
@@ -119,6 +119,21 @@ class IsmChatConfig {
   static bool? isMonthFirst;
   static ConversationVoidCallback? onConversationCreated;
   static bool? messageEncrypted;
+
+  /// When `true`, outgoing text is masked in local UI/DB (email, phone, social
+  /// URLs) while the **original** body is still sent to the backend.
+  ///
+  /// Default / unset = off — existing projects keep current behavior.
+  /// Enable only for apps that need this privacy rule:
+  /// ```dart
+  /// await IsmChat.i.initialize(
+  ///   maskSensitiveContent: true,
+  ///   // ...
+  /// );
+  /// ```
+  /// See [IsmChatSensitiveContentMasker] for formats and pending-retry handling.
+  static bool maskSensitiveContent = false;
+
   static NotificationBodyCallback? notificationBody;
 }
 

--- a/lib/src/utilities/sensitive_content_masker.dart
+++ b/lib/src/utilities/sensitive_content_masker.dart
@@ -1,0 +1,137 @@
+import 'package:isometrik_chat_flutter/src/models/meta_data_model.dart';
+
+/// Masks emails, phone numbers, and social profile URLs in message text.
+///
+/// **Reuse:** Call [mask] / [applyIfEnabled] from any send path that needs the
+/// same privacy rules. Keep [localUnmaskedBodyKey] only in local DB / pending
+/// meta — strip it with [stripLocalUnmaskedFromMeta] before API payloads.
+///
+/// Expected formats (asterisk count matches hidden length):
+/// - `nilpatel@gmail.com` → `********@gmail.com`
+/// - `9876543210` → `******3210`
+/// - `+91 9876543210` → `+91 ******3210`
+/// - `instagram.com/nilpatel` → `instagram.com/********`
+/// - `facebook.com/nilpatel` → `facebook.com/********`
+/// - `x.com/nilpatel` → `x.com/********`
+/// - `linkedin.com/in/nilpatel` → `linkedin.com/in/********`
+class IsmChatSensitiveContentMasker {
+  IsmChatSensitiveContentMasker._();
+
+  /// Local-only meta key holding the original body for pending retries / API.
+  /// Never leave this on outbound API meta payloads.
+  static const String localUnmaskedBodyKey = '__ismLocalUnmaskedBody';
+
+  /// Social profile URLs (optional scheme / www).
+  static final RegExp _socialRegExp = RegExp(
+    r'((?:https?:\/\/)?(?:www\.)?)'
+    r'(?:'
+    r'(instagram\.com|facebook\.com|x\.com|twitter\.com)\/([A-Za-z0-9._]+)'
+    r'|'
+    r'(linkedin\.com)\/in\/([A-Za-z0-9._-]+)'
+    r')',
+    caseSensitive: false,
+  );
+
+  static final RegExp _emailRegExp = RegExp(
+    r'\b([A-Z0-9._%+-]+)@([A-Z0-9.-]+\.[A-Z]{2,})\b',
+    caseSensitive: false,
+  );
+
+  /// Country-code phones must start with `+` (e.g. `+91 9876543210`).
+  static final RegExp _phoneWithCodeRegExp = RegExp(
+    r'(\+\d{1,3})([\s\-]?)(\d{9,13})\b',
+  );
+
+  /// Bare national / long numbers (9–13 digits).
+  static final RegExp _phonePlainRegExp = RegExp(r'(?<![\d+])(\d{9,13})\b');
+
+  /// Applies masking when [enabled] is true; otherwise returns [input] unchanged.
+  static String applyIfEnabled(String input, {required bool enabled}) {
+    if (!enabled || input.isEmpty) return input;
+    return mask(input);
+  }
+
+  /// Masks all supported sensitive patterns in [input].
+  static String mask(String input) {
+    if (input.isEmpty) return input;
+
+    var result = input;
+
+    result = result.replaceAllMapped(_socialRegExp, (match) {
+      final prefix = match.group(1) ?? '';
+      final host = match.group(2) ?? match.group(4) ?? '';
+      final user = match.group(3) ?? match.group(5) ?? '';
+      if (user.isEmpty || host.isEmpty) return match.group(0) ?? '';
+      final stars = '*' * user.length;
+      final hostLower = host.toLowerCase();
+      if (hostLower == 'linkedin.com') {
+        return '${prefix}linkedin.com/in/$stars';
+      }
+      return '$prefix$host/$stars';
+    });
+
+    result = result.replaceAllMapped(_emailRegExp, (match) {
+      final local = match.group(1) ?? '';
+      final domain = match.group(2) ?? '';
+      if (local.isEmpty || domain.isEmpty) return match.group(0) ?? '';
+      return '${'*' * local.length}@$domain';
+    });
+
+    result = result.replaceAllMapped(_phoneWithCodeRegExp, (match) {
+      final code = match.group(1) ?? '';
+      final sep = match.group(2) ?? ' ';
+      final number = match.group(3) ?? '';
+      if (number.isEmpty) return match.group(0) ?? '';
+      final spacer = sep.isEmpty ? ' ' : sep;
+      return '$code$spacer${_maskPhoneKeepLast4(number)}';
+    });
+
+    result = result.replaceAllMapped(_phonePlainRegExp, (match) {
+      final number = match.group(1) ?? '';
+      return _maskPhoneKeepLast4(number);
+    });
+
+    return result;
+  }
+
+  static String _maskPhoneKeepLast4(String digits) {
+    if (digits.length <= 4) return '*' * digits.length;
+    return '${'*' * (digits.length - 4)}${digits.substring(digits.length - 4)}';
+  }
+
+  /// Body to send to the backend: prefer local unmasked original when present.
+  static String resolveApiBody({
+    required String storedBody,
+    IsmChatMetaData? metaData,
+  }) {
+    final original =
+        metaData?.customMetaData?[localUnmaskedBodyKey]?.toString();
+    if (original != null && original.isNotEmpty) return original;
+    return storedBody;
+  }
+
+  /// Meta for API / push — drops local-only unmasked body key.
+  static IsmChatMetaData? stripLocalUnmaskedFromMeta(IsmChatMetaData? meta) {
+    if (meta == null) return null;
+    final custom = meta.customMetaData;
+    if (custom == null || !custom.containsKey(localUnmaskedBodyKey)) {
+      return meta;
+    }
+    final cleaned = Map<String, dynamic>.from(custom)
+      ..remove(localUnmaskedBodyKey);
+    return meta.copyWith(
+      customMetaData: cleaned.isEmpty ? {} : cleaned,
+    );
+  }
+
+  /// Builds meta that keeps original text for pending retry (local DB only).
+  static IsmChatMetaData attachLocalUnmasked({
+    required IsmChatMetaData? meta,
+    required String originalBody,
+  }) {
+    final base = meta ?? IsmChatMetaData();
+    final custom = Map<String, dynamic>.from(base.customMetaData ?? {});
+    custom[localUnmaskedBodyKey] = originalBody;
+    return base.copyWith(customMetaData: custom);
+  }
+}

--- a/lib/src/utilities/sensitive_content_masker.dart
+++ b/lib/src/utilities/sensitive_content_masker.dart
@@ -9,7 +9,8 @@ import 'package:isometrik_chat_flutter/src/models/meta_data_model.dart';
 /// Expected formats (asterisk count matches hidden length):
 /// - `nilpatel@gmail.com` → `********@gmail.com`
 /// - `9876543210` → `******3210`
-/// - `+91 9876543210` → `+91 ******3210`
+/// - `+91 9876543210` (space) → `+91 ******3210` (last 4 of national number)
+/// - `+919876543210` (no space) → `+9198******10` (first 4 + last 2 digits)
 /// - `instagram.com/nilpatel` → `instagram.com/********`
 /// - `facebook.com/nilpatel` → `facebook.com/********`
 /// - `x.com/nilpatel` → `x.com/********`
@@ -37,9 +38,14 @@ class IsmChatSensitiveContentMasker {
     caseSensitive: false,
   );
 
-  /// Country-code phones must start with `+` (e.g. `+91 9876543210`).
-  static final RegExp _phoneWithCodeRegExp = RegExp(
-    r'(\+\d{1,3})([\s\-]?)(\d{9,13})\b',
+  /// `+91 9876543210` / `+91-9876543210` — space or hyphen between code and number.
+  static final RegExp _phonePlusWithSeparatorRegExp = RegExp(
+    r'(\+\d{1,3})([\s\-]+)(\d{9,13})\b',
+  );
+
+  /// `+919876543210` — `+` with digits and no separator.
+  static final RegExp _phonePlusContinuousRegExp = RegExp(
+    r'\+(\d{10,15})\b',
   );
 
   /// Bare national / long numbers (9–13 digits).
@@ -77,13 +83,20 @@ class IsmChatSensitiveContentMasker {
       return '${'*' * local.length}@$domain';
     });
 
-    result = result.replaceAllMapped(_phoneWithCodeRegExp, (match) {
+    // Spaced / hyphenated country code: keep code + separator, mask national (last 4).
+    result = result.replaceAllMapped(_phonePlusWithSeparatorRegExp, (match) {
       final code = match.group(1) ?? '';
       final sep = match.group(2) ?? ' ';
       final number = match.group(3) ?? '';
       if (number.isEmpty) return match.group(0) ?? '';
-      final spacer = sep.isEmpty ? ' ' : sep;
-      return '$code$spacer${_maskPhoneKeepLast4(number)}';
+      return '$code$sep${_maskPhoneKeepLast4(number)}';
+    });
+
+    // Continuous `+9198…`: show first 4 digits + last 2 digits.
+    result = result.replaceAllMapped(_phonePlusContinuousRegExp, (match) {
+      final digits = match.group(1) ?? '';
+      if (digits.isEmpty) return match.group(0) ?? '';
+      return '+${_maskPhoneKeepFirst4Last2(digits)}';
     });
 
     result = result.replaceAllMapped(_phonePlainRegExp, (match) {
@@ -94,9 +107,27 @@ class IsmChatSensitiveContentMasker {
     return result;
   }
 
+  /// `9876543210` → `******3210` (hide all but last 4).
   static String _maskPhoneKeepLast4(String digits) {
     if (digits.length <= 4) return '*' * digits.length;
     return '${'*' * (digits.length - 4)}${digits.substring(digits.length - 4)}';
+  }
+
+  /// `919876543210` → `9198******10` (keep first 4 + last 2).
+  static String _maskPhoneKeepFirst4Last2(String digits) {
+    if (digits.length <= 6) {
+      // Too short to split meaningfully — still hide the middle when possible.
+      if (digits.length <= 2) return '*' * digits.length;
+      final last2 = digits.substring(digits.length - 2);
+      final headLen = digits.length > 4 ? 4 : digits.length - 2;
+      final head = digits.substring(0, headLen);
+      final middleLen = digits.length - headLen - 2;
+      return '$head${'*' * (middleLen > 0 ? middleLen : 0)}$last2';
+    }
+    final head = digits.substring(0, 4);
+    final tail = digits.substring(digits.length - 2);
+    final middleLen = digits.length - 6;
+    return '$head${'*' * middleLen}$tail';
   }
 
   /// Body to send to the backend: prefer local unmasked original when present.

--- a/lib/src/utilities/utilities.dart
+++ b/lib/src/utilities/utilities.dart
@@ -6,6 +6,7 @@ export 'config/config.dart';
 export 'debouncer.dart';
 export 'enums.dart';
 export 'extensions/extensions.dart';
+export 'sensitive_content_masker.dart';
 export 'show_context.dart';
 export 'typedef.dart';
 export 'utility.dart';


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Implement a new sensitive content masking feature that masks emails, phone numbers, and social profile URLs in outgoing messages within the chat application. When enabled via configuration, the masking applies locally to the message body and related metadata before sending, ensuring that sensitive information is obscured in the user interface and local database, while the original unmasked content is still sent to the backend API. The feature also preserves the original message body in local-only metadata for pending retries and strips this information before API payloads. This enhancement provides increased privacy control for users by masking sensitive data in local displays without affecting message delivery.
<!-- kody-pr-summary:end -->