### PR TITLE
Fix: Fix OrderId related content should not mask

### DIFF
--- a/lib/src/utilities/sensitive_content_masker.dart
+++ b/lib/src/utilities/sensitive_content_masker.dart
@@ -49,8 +49,11 @@ class IsmChatSensitiveContentMasker {
   );
 
   /// Bare national / long numbers (9–13 digits).
-  static final RegExp _phonePlainRegExp = RegExp(r'(?<![\d+])(\d{9,13})\b');
-
+  /// Skips ID-style tokens like `MID-0000079377` / `SID-…` / `PKID-…`
+  /// (letter(s) + hyphen immediately before the digits).
+  static final RegExp _phonePlainRegExp = RegExp(
+    r'(?<![A-Za-z]-)(?<![\d+])(\d{9,13})\b',
+  );
   /// Applies masking when [enabled] is true; otherwise returns [input] unchanged.
   static String applyIfEnabled(String input, {required bool enabled}) {
     if (!enabled || input.isEmpty) return input;


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the regular expression used for detecting plain phone number sequences within the sensitive content masker. The modification enhances the pattern to exclude matches that are part of ID-style tokens (such as MID-0000079377, SID-..., or PKID-...), by ensuring that the digits are not immediately preceded by a letter and hyphen combination. This change aims to improve the accuracy of phone number masking by preventing false positives on ID-like tokens, thereby reducing unintended masking of non-phone number content.
<!-- kody-pr-summary:end -->